### PR TITLE
Safeguard against options not being passed in.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function format (obj, fn) {
 
 formData.parse = function (options) {
   return function (req, res) {
-    if(options.autoClean) {
+    if(options && options.autoClean) {
       res.on('finish', () => {
         const clean = [];
 


### PR DESCRIPTION
This wasn't an issue before since they were just being passed directly into `connect-multiparty` for which they were optional.