### PR TITLE
fixed missing content-type header request errors

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -11,8 +11,8 @@ function multipart (options) {
     if (req._body) return next();
     req.body = req.body || {};
     req.files = req.files || {};
-    ('GET' === req.method || 'HEAD') === req.method && next();
-    (!typeis(req, 'multipart/form-data')) && next();
+    if ('GET' === req.method || 'HEAD' === req.method) return next();
+    if (!typeis(req, 'multipart/form-data')) return next();
     req._body = true;
     let form = new multiparty.Form(options);
     let data = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-form-data",
-  "version": "2.0.23",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-form-data",
-      "version": "2.0.23",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-form-data",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Module to parse multipart/form data",
   "main": "./index.js",
   "author": {


### PR DESCRIPTION
Upon updating to version 3.0.0 I noticed that requests failed due to missing content-type headers.
This change attempts to fix these errors.

Tested locally with the provided test script and a small express app. No errors occured,